### PR TITLE
Print unhandled error in showInfo command

### DIFF
--- a/src/helpers/scratch-org.js
+++ b/src/helpers/scratch-org.js
@@ -12,11 +12,16 @@ function deleteOrg(username) {
 }
 
 async function showInfo(markdown, alias) {
-  const info = await getInfo(alias);
-  if (markdown) {
-    drawMarkdownTable(info);
-  } else {
-    drawTable(info);
+  try {
+    const info = await getInfo(alias);
+    if (markdown) {
+      drawMarkdownTable(info);
+    } else {
+      drawTable(info);
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where exceptions are not propagated and hides the error from the user

eg.

**BEFORE**

```
$ ./bin/run info

(node:22429) UnhandledPromiseRejectionWarning: Error: Command failed: sfdx force:org:display --json

    at ChildProcess.exithandler (child_process.js:303:12)
    at ChildProcess.emit (events.js:311:20)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:443:11)
    at Socket.emit (events.js:311:20)
    at Pipe.<anonymous> (net.js:668:12)
(node:22429) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:22429) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**AFTER**

```
$ ./bin/run info

Error: Command failed: sfdx force:org:display --json

    at ChildProcess.exithandler (child_process.js:303:12)
    at ChildProcess.emit (events.js:311:20)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:443:11)
    at Socket.emit (events.js:311:20)
    at Pipe.<anonymous> (net.js:668:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'sfdx force:org:display --json',
  stdout: '{\n' +
    '  "status": 1,\n' +
    '  "name": "oauthInvalidGrant",\n' +
...
```